### PR TITLE
Add missing function parameter and fix some docstrings

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -86,14 +86,13 @@ python-oauth2 is available on
 """
 
 import json
-import time
-import urllib
 from oauth2.error import OAuthInvalidError, OAuthUserError
 from oauth2.web import Request, Response
 from oauth2.tokengenerator import Uuid4
 from oauth2.grant import Scope
 
 VERSION = "0.5.0"
+
 
 class Provider(object):
     authorize_path = "/authorize"
@@ -181,5 +180,5 @@ class Provider(object):
                 return grant_handler
         
         raise OAuthInvalidError(error="unsupported_response_type",
-                              explanation="Server does not support given " \
-                              "response_type")
+                                explanation="Server does not support given "
+                                "response_type")

--- a/oauth2/store/__init__.py
+++ b/oauth2/store/__init__.py
@@ -6,6 +6,7 @@ solution specific to your needs.
 It also includes implementations for popular storage systems like memcache.
 """
 
+
 class AccessTokenStore(object):
     """
     Base class for persisting an access token after it has been generated.
@@ -27,8 +28,12 @@ class AccessTokenStore(object):
         identify it.
         
         :param refresh_token: A string containing the refresh token.
+        :return: An instance of :class:`oauth2.datatype.AccessToken`.
+        :raises: :class:`oauth2.error.AccessTokenNotFound` if no data could be retrieved for
+                 given refresh_token.
         """
         raise NotImplementedError
+
 
 class AuthCodeStore(object):
     """
@@ -41,7 +46,7 @@ class AuthCodeStore(object):
         
         :param code: The authorization code.
         :return: An instance of :class:`oauth2.datatype.AuthorizationCode`.
-        :raises: :class:`AuthCodeNotFound` if no data could be retrieved for
+        :raises: :class:`oauth2.error.AuthCodeNotFound` if no data could be retrieved for
                  given code.
         
         """
@@ -52,10 +57,10 @@ class AuthCodeStore(object):
         Stores the data belonging to an authorization code token.
         
         :param authorization_code: An instance of
-                                   :class:`oauth2.AuthorizationCode`.
-        
+                                   :class:`oauth2.datatype.AuthorizationCode`.
         """
         raise NotImplementedError
+
 
 class ClientStore(object):
     """
@@ -66,8 +71,8 @@ class ClientStore(object):
         Retrieve a client by its identifier.
         
         :param client_id: Identifier of a client app.
-        :return: An instance of :class:`oauth2.Client`.
-        :raises: ClientNotFoundError
-        
+        :return: An instance of :class:`oauth2.datatype.Client`.
+        :raises: :class:`oauth2.error.ClientNotFoundError` if no data could be retrieved for
+                 given client_id.
         """
         raise NotImplementedError

--- a/oauth2/web.py
+++ b/oauth2/web.py
@@ -27,13 +27,15 @@ class SiteAdapter(object):
         """
         raise NotImplementedError
     
-    def render_auth_page(self, request, response, environ):
+    def render_auth_page(self, request, response, environ, scopes):
         """
         Defines how to display a confirmation page to the user.
 
         :param request: An instance of :class:`oauth2.web.Request`.
         :param response: An instance of :class:`oauth2.web.Response`.
         :param environ: Environment variables of the request.
+        :param scopes: A list of strings with each string being one requested
+                       scope.
         :return: The response passed in as a parameter.
                  It can contain HTML or issue a redirect.
         """


### PR DESCRIPTION
- Fix a few PEP-8 whitespace issues
- Fix some bad docstring with incorrect FQ class references
- Add missing `scope` parameter to `oauth2.web.SiteAdapter.render_auth_page` since it is called in `oauth2/grant.py` as:

``` python
return self.site_adapter.render_auth_page(request, response,
                                          environ,
                                          self.scope_handler.scopes)
```
