### PR TITLE
Add interface for deleting an authorization code after it's one time use

### DIFF
--- a/oauth2/grant.py
+++ b/oauth2/grant.py
@@ -376,12 +376,13 @@ class AuthorizationCodeTokenHandler(GrantHandler):
             access_token.refresh_token = token_data["refresh_token"]
         
         self.access_token_store.save_token(access_token)
-        
+        self.auth_code_store.delete_code(self.code)
+
         response.body = json.dumps(token_data)
         response.status_code = 200
         
         response.add_header("Content-type", "application/json")
-        
+
         return response
     
     def redirect_oauth_error(self, error, response):

--- a/oauth2/store/__init__.py
+++ b/oauth2/store/__init__.py
@@ -61,6 +61,16 @@ class AuthCodeStore(object):
         """
         raise NotImplementedError
 
+    def delete_code(self, code):
+        """
+        Deletes an authorization code after it's use per section 4.1.2.
+
+        http://tools.ietf.org/html/rfc6749#section-4.1.2
+
+        :param code: The authorization code.
+        """
+        raise NotImplementedError
+
 
 class ClientStore(object):
     """

--- a/oauth2/store/memcache.py
+++ b/oauth2/store/memcache.py
@@ -64,7 +64,14 @@ class TokenStore(AccessTokenStore, AuthCodeStore):
                           "redirect_uri": authorization_code.redirect_uri,
                           "scopes": authorization_code.scopes,
                           "data": authorization_code.data})
-    
+
+    def delete_code(self, code):
+        """
+        Deletes an authorization code after use
+        :param code: The authorization code.
+        """
+        self.mc.delete(self._generate_cache_key(code))
+
     def save_token(self, access_token):
         """
         Stores the access token and additional data in memcache.

--- a/oauth2/store/memory.py
+++ b/oauth2/store/memory.py
@@ -98,6 +98,14 @@ class TokenStore(AccessTokenStore, AuthCodeStore):
             self.refresh_tokens[access_token.refresh_token] = access_token
         
         return True
+
+    def delete_code(self, code):
+        """
+        Deletes an authorization code after use
+        :param code: The authorization code.
+        """
+        if code in self.auth_codes:
+            del self.auth_codes[code]
     
     def fetch_by_refresh_token(self, refresh_token):
         """

--- a/oauth2/store/mongodb.py
+++ b/oauth2/store/mongodb.py
@@ -93,6 +93,14 @@ class AuthCodeStore(AuthCodeStore, MongodbStore):
         
         return True
 
+    def delete_code(self, code):
+        """
+        Deletes an authorization code after use
+        :param code: The authorization code.
+        """
+        self.collection.remove({"code": code})
+
+
 class ClientStore(ClientStore, MongodbStore):
     """
     Create a new instance like this::

--- a/oauth2/test/test_grant.py
+++ b/oauth2/test/test_grant.py
@@ -688,6 +688,8 @@ class AuthorizationCodeTokenHandlerTestCase(unittest.TestCase):
         scopes       = ["scope"]
         
         access_token_store_mock = Mock(spec=AccessTokenStore)
+        auth_code_store_mock = Mock(spec=AuthCodeStore)
+        client_store_mock = Mock(spec=ClientStore)
         
         token_generator_mock = Mock(spec=TokenGenerator)
         token_generator_mock.create_access_token_data.return_value = token_data
@@ -697,14 +699,15 @@ class AuthorizationCodeTokenHandlerTestCase(unittest.TestCase):
         response_mock.status_code = None
         
         handler = AuthorizationCodeTokenHandler(access_token_store_mock,
-                                                Mock(spec=AuthCodeStore),
-                                                Mock(spec=ClientStore),
+                                                auth_code_store_mock,
+                                                client_store_mock,
                                                 token_generator_mock)
         handler.client_id = client_id
         handler.data = data
         handler.scopes = scopes
         response = handler.process(Mock(spec=Request), response_mock, {})
-        
+
+        self.assertIsNotNone(auth_code_store_mock.delete_code.call_args)
         access_token, = access_token_store_mock.save_token.call_args[0]
         self.assertTrue(isinstance(access_token, AccessToken))
         self.assertEqual(access_token.data, data)
@@ -722,7 +725,9 @@ class AuthorizationCodeTokenHandlerTestCase(unittest.TestCase):
         scopes       = ["scope"]
         
         access_token_store_mock = Mock(spec=AccessTokenStore)
-        
+        auth_code_store_mock = Mock(spec=AuthCodeStore)
+        client_store_mock = Mock(spec=ClientStore)
+
         token_generator_mock = Mock(spec=TokenGenerator)
         token_generator_mock.create_access_token_data.return_value = token_data
         
@@ -731,14 +736,15 @@ class AuthorizationCodeTokenHandlerTestCase(unittest.TestCase):
         response_mock.status_code = None
         
         handler = AuthorizationCodeTokenHandler(access_token_store_mock,
-                                                Mock(spec=AuthCodeStore),
-                                                Mock(spec=ClientStore),
+                                                auth_code_store_mock,
+                                                client_store_mock,
                                                 token_generator_mock)
         handler.client_id = client_id
         handler.data = data
         handler.scopes = scopes
         response = handler.process(Mock(spec=Request), response_mock, {})
-        
+
+        self.assertIsNotNone(auth_code_store_mock.delete_code.call_args)
         access_token, = access_token_store_mock.save_token.call_args[0]
         self.assertTrue(isinstance(access_token, AccessToken))
         self.assertEqual(access_token.data, data)


### PR DESCRIPTION
4.1.2.  Authorization Response

   If the resource owner grants the access request, the authorization
   server issues an authorization code and delivers it to the client by
   adding the following parameters to the query component of the
   redirection URI using the "application/x-www-form-urlencoded" format,
   per Appendix B:

   code
         REQUIRED.  The authorization code generated by the
         authorization server.  The authorization code MUST expire
         shortly after it is issued to mitigate the risk of leaks.  A
         maximum authorization code lifetime of 10 minutes is
         RECOMMENDED.  _The client MUST NOT use the authorization code
         more than once._  If an authorization code is used more than
         once, the authorization server MUST deny the request and SHOULD
         revoke (when possible) all tokens previously issued based on
         that authorization code.  The authorization code is bound to
         the client identifier and redirection URI.

Add unit test to make sure that `AuthCodeStore.delete_code()` is called
during `process()`
