### PR TITLE
miss oauth2.web

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name="python-oauth2",
       author="Markus Meyer",
       author_email="hydrantanderwand@gmail.com",
       url="https://github.com/wndhydrnt/python-oauth2",
-      packages=["oauth2", "oauth2.store", "oauth2.store.dbapi",
+      packages=["oauth2", "oauth2.web", "oauth2.store", "oauth2.store.dbapi",
                 "oauth2.test"],
       extras_require={
         "memcache": [memcache_require],


### PR DESCRIPTION
hi, dude, you miss the oauth2.web in setup.py, when install from this git repo, try to import oauth2, got error: ImportError ...  No module named web

Signed-off-by: yxy <yxy.870@gmail.com>