### PR TITLE
Fix 'unsupported_grant_type' error in examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,18 @@ Example Authorization server
     # This can be used to display confirmation dialogs and the like.
     class ExampleSiteAdapter(oauth2.web.AuthorizationCodeGrantSiteAdapter,
                              oauth2.web.ImplicitGrantSiteAdapter):
+        TEMPLATE = '''
+    <html>
+        <body>
+            <p>
+                <a href="{url}&confirm=confirm">confirm</a>
+            </p>
+            <p>
+                <a href="{url}&deny=deny">deny</a>
+            </p>
+        </body>
+    </html>'''
+
         def authenticate(self, request, environ, scopes, client):
             # Check if the user has granted access
             if request.post_param("confirm") == "confirm":
@@ -51,15 +63,8 @@ Example Authorization server
 
         def render_auth_page(self, request, response, environ, scopes,
                              client):
-            response.body = '''
-    <html>
-        <body>
-            <form method="POST" name="confirmation_form">
-                <input type="submit" name="confirm" value="confirm" />
-                <input type="submit" name="deny" value="deny" />
-            </form>
-        </body>
-    </html>'''
+            url = request.path + "?" + request.query_string
+            response.body = self.TEMPLATE.format(url=url)
             return response
 
         def user_has_denied_access(self, request):

--- a/docs/examples/authorization_code_grant.py
+++ b/docs/examples/authorization_code_grant.py
@@ -52,36 +52,31 @@ class TestSiteAdapter(AuthorizationCodeGrantSiteAdapter):
     CONFIRMATION_TEMPLATE = """
 <html>
     <body>
-        <form method="POST" name="confirmation_form">
-            <input name="confirm" type="hidden" value="1" />
-            <div>
-                <input type="submit" value="confirm" />
-            </div>
-        </form>
-        <form method="POST" name="confirmation_form">
-            <input name="confirm" type="hidden" value="0" />
-            <div>
-                <input type="submit" value="deny" />
-            </div>
-        </form>
+        <p>
+            <a href="{url}&confirm=1">confirm</a>
+        </p>
+        <p>
+            <a href="{url}&confirm=0">deny</a>
+        </p>
     </body>
 </html>
     """
 
     def render_auth_page(self, request, response, environ, scopes, client):
-        response.body = self.CONFIRMATION_TEMPLATE
+        url = request.path + "?" + request.query_string
+        response.body = self.CONFIRMATION_TEMPLATE.format(url=url)
 
         return response
 
     def authenticate(self, request, environ, scopes, client):
-        if request.method == "POST":
-            if request.post_param("confirm") == "1":
+        if request.method == "GET":
+            if request.get_param("confirm") == "1":
                 return
         raise UserNotAuthenticated
 
     def user_has_denied_access(self, request):
-        if request.method == "POST":
-            if request.post_param("confirm") == "0":
+        if request.method == "GET":
+            if request.get_param("confirm") == "0":
                 return True
         return False
 

--- a/docs/examples/implicit_grant.py
+++ b/docs/examples/implicit_grant.py
@@ -24,37 +24,32 @@ class TestSiteAdapter(ImplicitGrantSiteAdapter):
     CONFIRMATION_TEMPLATE = """
 <html>
     <body>
-        <form method="POST" name="confirmation_form">
-            <input name="confirm" type="hidden" value="1" />
-            <div>
-                <input type="submit" value="confirm" />
-            </div>
-        </form>
-        <form method="POST" name="confirmation_form">
-            <input name="confirm" type="hidden" value="0" />
-            <div>
-                <input type="submit" value="deny" />
-            </div>
-        </form>
+        <p>
+            <a href="{url}&confirm=1">confirm</a>
+        </p>
+        <p>
+            <a href="{url}&confirm=0">deny</a>
+        </p>
     </body>
 </html>
     """
 
     def render_auth_page(self, request, response, environ, scopes, client):
+        url = request.path + "?" + request.query_string
         # Add check if the user is logged or a redirect to the login page here
-        response.body = self.CONFIRMATION_TEMPLATE
+        response.body = self.CONFIRMATION_TEMPLATE.format(url=url)
 
         return response
 
     def authenticate(self, request, environ, scopes, client):
-        if request.method == "POST":
-            if request.post_param("confirm") == "1":
+        if request.method == "GET":
+            if request.get_param("confirm") == "1":
                 return
         raise UserNotAuthenticated
 
     def user_has_denied_access(self, request):
-        if request.method == "POST":
-            if request.post_param("confirm") == "0":
+        if request.method == "GET":
+            if request.get_param("confirm") == "0":
                 return True
         return False
 

--- a/docs/examples/tornado_server.py
+++ b/docs/examples/tornado_server.py
@@ -54,36 +54,31 @@ class TestSiteAdapter(AuthorizationCodeGrantSiteAdapter):
     CONFIRMATION_TEMPLATE = """
 <html>
     <body>
-        <form method="POST" name="confirmation_form">
-            <input name="confirm" type="hidden" value="1" />
-            <div>
-                <input type="submit" value="confirm" />
-            </div>
-        </form>
-        <form method="POST" name="confirmation_form">
-            <input name="confirm" type="hidden" value="0" />
-            <div>
-                <input type="submit" value="deny" />
-            </div>
-        </form>
+        <p>
+            <a href="{url}&confirm=1">confirm</a>
+        </p>
+        <p>
+            <a href="{url}&confirm=0">deny</a>
+        </p>
     </body>
 </html>
     """
 
     def render_auth_page(self, request, response, environ, scopes, client):
-        response.body = self.CONFIRMATION_TEMPLATE
+        url = request.path + "?" + request.query_string
+        response.body = self.CONFIRMATION_TEMPLATE.format(url=url)
 
         return response
 
     def authenticate(self, request, environ, scopes, client):
-        if request.method == "POST":
-            if request.post_param("confirm") == "1":
+        if request.method == "GET":
+            if request.get_param("confirm") == "1":
                 return
         raise UserNotAuthenticated
 
     def user_has_denied_access(self, request):
-        if request.method == "POST":
-            if request.post_param("confirm") == "0":
+        if request.method == "GET":
+            if request.get_param("confirm") == "0":
                 return True
         return False
 

--- a/oauth2/web/tornado.py
+++ b/oauth2/web/tornado.py
@@ -32,6 +32,10 @@ class Request(object):
     def path(self):
         return self.handler.request.path
 
+    @property
+    def query_string(self):
+        return self.handler.request.query
+
     def get_param(self, name, default=None):
         return self.handler.get_query_argument(name=name, default=default)
 


### PR DESCRIPTION
Checking for the correct request method was introduced by #42. This caused
the to raise an error because the HTML form on the confirmation page used
the wrong HTTP method.

Fixes #50