### PR TITLE
Add error message to response for bad redirect URIs

### DIFF
--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -119,6 +119,11 @@ class Provider(object):
             response = self.response_class()
             response.add_header("Content-Type", "text/plain")
             response.status_code = 400
+            response.body = json.dumps({
+                "error": "invalid_redirect_uri",
+                "error_description": "Invalid redirect URI"
+            })
+
             return response
         except OAuthInvalidError as err:
             response = self.response_class()

--- a/oauth2/__init__.py
+++ b/oauth2/__init__.py
@@ -117,7 +117,7 @@ class Provider(object):
             return grant_type.process(request, response, environ)
         except OAuthInvalidNoRedirectError:
             response = self.response_class()
-            response.add_header("Content-Type", "text/plain")
+            response.add_header("Content-Type", "application/json")
             response.status_code = 400
             response.body = json.dumps({
                 "error": "invalid_redirect_uri",

--- a/oauth2/test/test_oauth2.py
+++ b/oauth2/test/test_oauth2.py
@@ -105,9 +105,9 @@ class ProviderTestCase(unittest.TestCase):
         self.auth_server.dispatch(request_mock, {})
 
         self.response_mock.add_header.assert_called_with("Content-Type",
-                                                         "text/plain")
+                                                         "application/json")
         self.assertEqual(self.response_mock.status_code, 400)
-        self.assertEqual(self.response_mock.body, "")
+        self.assertEqual(json.loads(self.response_mock.body)["error"], "invalid_redirect_uri")
 
     def test_dispatch_general_exception(self):
         request_mock = Mock(spec=Request)


### PR DESCRIPTION
Troubleshooting when a bad redirect URI is passed in is difficult because there's no message returned with the http 400 response; this adds a human-readable "Invalid redirect URI" response to clue the remote developer in on what the problem is.